### PR TITLE
fix travis ci firebase deploy bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,6 @@ script:
 after_success:
 - npm run ci:upload-coveralls
 
-before_deploy:
-- npm -i g firebase-tools
-
 deploy:
   provider: firebase
   skip_cleanup: true


### PR DESCRIPTION
The fix for the bug is actually in Travis CI firebase gem: https://github.com/travis-ci/dpl/issues/890 
But I did want to remove the firebase-tools install if not needed. (Since I noticed it was not using the firebase-tools that was getting installed globally but was using the firebase gem that Travis CI had)